### PR TITLE
Fixes a call to a non existent function

### DIFF
--- a/rtl_433/rtl_433.js
+++ b/rtl_433/rtl_433.js
@@ -116,7 +116,7 @@ module.exports = function(RED) {
       var loop = setInterval( function() {
         if (!node.running) {
           node.warn("Restarting : " + node.cmd);
-          runit();
+          runRtl433()
         }
       }, 10000);  // Restart after 10 secs if required
     }


### PR DESCRIPTION
Changes the call to runit(), the function to start the process in the original daemon code that this node is based on, to a call to runRtl433(), what the function was renamed to.