### PR TITLE
Fix the command for installing rtl_433

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ You will need a working version of the `rtl_433` tool in your environment and va
 
 Those on Raspbian, Ubuntu, or Debian based systems could use the following helper script to install it:
 ```
-curl
-https://raw.githubusercontent.com/dayne/node-red-contrib-rtl_433/master/install-rtl_433-app
-| bash
+curl https://raw.githubusercontent.com/dayne/node-red-contrib-rtl_433/master/install-rtl_433-app | bash
 ```
 
 **`reboot`** after that is completed. 


### PR DESCRIPTION
In Readme.md the rtl_433 command has newlines seperating it for some reason which makes annoying to paste into a terminal.